### PR TITLE
Add support for `\u{X}` form

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,21 @@ pub fn unescape(s: &str) -> Option<String> {
 fn unescape_unicode(queue: &mut VecDeque<char>) -> Option<char> {
     let mut s = String::new();
 
-    for _ in 0..4 {
-        s.push(try_option!(queue.pop_front()));
+    if try_option!(queue.front()) == &'{' {
+        // \u{X} form with an arbitrary number of digits.
+        queue.pop_front();
+        'outer: loop {
+            match queue.pop_front() {
+                Some('}') => break 'outer,
+                Some(c) => s.push(c),
+                None => return None,
+            }
+        }
+    } else {
+        // \uXXXX form with exactly four digits.
+        for _ in 0..4 {
+            s.push(try_option!(queue.pop_front()));
+        }
     }
 
     let u = try_option!(u32::from_str_radix(&s, 16).ok());

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -29,6 +29,13 @@ fn control_chars() {
 fn unicode_chars() {
     assert_some_string!("\n", r"\u000A");
     assert_some_string!("\u{1234}", r"\u1234");
+    assert_some_string!("\u{1234}", r"\u{1234}");
+    assert_some_string!("\u{A}", r"\u{a}");
+
+    assert_eq!(None, unescape(r"\u000G"));
+    assert_eq!(None, unescape(r"\u0A"));
+    assert_eq!(None, unescape(r"\u{}"));
+    assert_eq!(None, unescape(r"\u{a"));
 }
 
 #[test]
@@ -41,4 +48,12 @@ fn byte_chars() {
 fn octal_chars() {
     assert_some_string!("\n", r"\12");
     assert_some_string!("\u{00C4}", r"\304");
+}
+
+#[test]
+fn revert_escape_default() {
+    let original = "Some\ttest with ÜñıⒸºḋᴱ and\\traditional\nC-escape codes";
+    let escaped = original.escape_default().to_string();
+    println!("{}", escaped);
+    assert_some_string!(original, &escaped);
 }


### PR DESCRIPTION
This implements support for the `\u{1234}` Unicode form which allows for an arbitrary number of hex digits. Rust is using these for escaping as well, so by implementing this `unescape` should now cover most cases of `str::escape_default`. A test for this has been added as well.