### PR TITLE
Implement full LegacyOctalEscapeSequence support

### DIFF
--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -41,4 +41,10 @@ fn byte_chars() {
 fn octal_chars() {
     assert_some_string!("\n", r"\12");
     assert_some_string!("\u{00C4}", r"\304");
+    assert_some_string!("\0ABC", r"\0ABC");
+    assert_some_string!("\0", r"\0");
+    assert_some_string!("\u{7}ABC", r"\7ABC");
+    assert_some_string!("\u{7}ABC", r"\007ABC");
+    assert_some_string!("\u{A}9", r"\129");
+    assert_some_string!("\u{23}2", r"\432");
 }


### PR DESCRIPTION
This adds full support for parsing octal sequences as specified by [section B.1.2 in ECMAScript 6.0](https://ecma-international.org/ecma-262/6.0/#sec-additional-syntax-string-literals). 

Main motivation: This also fixes/implements support for `\0`.